### PR TITLE
Mark the CreateFromApiKey as obsolete

### DIFF
--- a/src/Skybrud.Social.Meetup/MeetupService.cs
+++ b/src/Skybrud.Social.Meetup/MeetupService.cs
@@ -104,6 +104,7 @@ namespace Skybrud.Social.Meetup {
         /// </summary>
         /// <param name="apiKey">The API key.</param>
         /// <returns>A new instance of <see cref="MeetupService"/>.</returns>
+        [Obsolete("The API keys are not supported anymore, migrate to OAuth2 or use Create()", true)]
         public static MeetupService CreateFromApiKey(string apiKey) {
             if (String.IsNullOrWhiteSpace(apiKey)) throw new ArgumentNullException(nameof(apiKey));
             return new MeetupService(new MeetupOAuth2Client { ApiKey = apiKey });


### PR DESCRIPTION
It won't work anymore with an API key.
Only marked it as obsolete with "error: true" so it won't compile if someone tries to use it.